### PR TITLE
Fix pubsub_ws example

### DIFF
--- a/pubsub/more-examples/examples/pubsub_ws.rs
+++ b/pubsub/more-examples/examples/pubsub_ws.rs
@@ -24,7 +24,7 @@ use jsonrpc_core::futures::Future;
 ///     jsonrpc: "2.0",
 ///     id: 1,
 ///     method: "subscribe_hello",
-///     params: [],
+///     params: null,
 ///   }));
 /// });
 ///


### PR DESCRIPTION
`params: []` will be parsed into Params::Array([]) instead of Params::None.

Another solution to fix the problem is to change Params::None to Params::Array(vec![]) in [#L46](https://github.com/paritytech/jsonrpc/blob/master/pubsub/more-examples/examples/pubsub_ws.rs#L46).